### PR TITLE
Fixed read more overlay z-index.

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -92,6 +92,7 @@ a {
   bottom: 0;
   left: 0;
   overflow: auto;
+  z-index: 15;
 }
 
 .modal-content p {


### PR DESCRIPTION
The "Read More" overlay is colliding with the conference track header.
On mobile, this makes some talk descriptions entirely obscured.
The track header is at z-index 10, so I've bumped the read more overlay to 15.

Before 
![image](https://user-images.githubusercontent.com/11706994/173421125-75e4fa1a-43fc-40a8-8d4c-ad3315a07584.png)

After
![image](https://user-images.githubusercontent.com/11706994/173421356-3a89cbd8-c801-4785-bdce-8da44a96872a.png)

