### PR TITLE
Fix schedule flicker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env

--- a/pages/api/airtable.js
+++ b/pages/api/airtable.js
@@ -1,19 +1,27 @@
 const apiKey = process.env.NEXT_PUBLIC_AIRTABLE_API_KEY;
 const apiBase = "https://api.airtable.com/v0/appsFsySYgjKqDoLu";
 
-async function get(endpoint, body = null) {
-  return fetch(`${apiBase}${endpoint}`, {
+async function get(endpoint, cache) {
+  const url = `${apiBase}${endpoint}`
+  return fetch(url, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
   })
-    .then((res) => res.json())
+    .then((res) => {
+      if (cache) {
+        const cloned = res.clone();
+        cloned.headers.set("Cache-Control", "max-age=60");
+        cache.put(url, cloned);
+      }
+      return res.json();
+    })
     .then((json) => json.records);
 }
 
-export async function getSchedule() {
-  return get("/Schedule");
+export async function getSchedule(cache) {
+  return get("/Schedule", cache);
 }
 
 export async function getSponsors() {

--- a/pages/api/airtable.js
+++ b/pages/api/airtable.js
@@ -2,22 +2,33 @@ const apiKey = process.env.NEXT_PUBLIC_AIRTABLE_API_KEY;
 const apiBase = "https://api.airtable.com/v0/appsFsySYgjKqDoLu";
 
 async function get(endpoint, cache) {
-  const url = `${apiBase}${endpoint}`
-  return fetch(url, {
+  const url = `${apiBase}${endpoint}`;
+
+  const cached = await cache?.match(url);
+
+  if (cached) {
+    return extractJson(cached);
+  }
+
+  const res = await fetch(url, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
-  })
-    .then((res) => {
-      if (cache) {
-        const cloned = res.clone();
-        cloned.headers.set("Cache-Control", "max-age=60");
-        cache.put(url, cloned);
-      }
-      return res.json();
-    })
-    .then((json) => json.records);
+  });
+
+  if (cache) {
+    const cloned = res.clone();
+    cloned.headers.set("Cache-Control", "max-age=60");
+    cache.put(url, cloned);
+  }
+
+  return extractJson(res);
+}
+
+async function extractJson(res) {
+  const json = await res.json();
+  return json.records;
 }
 
 export async function getSchedule(cache) {

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -1,10 +1,8 @@
 import * as airtable from "./api/airtable";
-import { useRouter } from "next/router";
 import Layout from "../layouts/default";
 import Schedule from "../components/Schedule";
 
-export default function SchedulePage({ schedule }) {
-  const { query } = useRouter();
+export default function SchedulePage({ schedule, query }) {
   const filter = query.share?.split(",") ?? [];
 
   return (
@@ -14,13 +12,14 @@ export default function SchedulePage({ schedule }) {
   );
 }
 
-export async function getStaticProps() {
-  const schedule = await airtable.getSchedule();
+export async function getServerSideProps({ query }) {
+  const cache = typeof caches !== "undefined" ? caches?.default : undefined;
+  const schedule = await airtable.getSchedule(cache);
 
   return {
     props: {
       schedule,
+      query
     },
-    revalidate: 60,
   };
 }

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -13,6 +13,7 @@ export default function SchedulePage({ schedule, query }) {
 }
 
 export async function getServerSideProps({ query }) {
+  // Cache isn't available locally, only in a Cloudflare Workers environment
   const cache = typeof caches !== "undefined" ? caches?.default : undefined;
   const schedule = await airtable.getSchedule(cache);
 


### PR DESCRIPTION
This works by using SSR for the schedule instead of SSG. This means that the page is dynamically loaded for each visitor, and without caching we would also hit airtable for each visitor too. To prevent overloading airtable we can use the Cache API and cache the response for 60 seconds.

https://developers.cloudflare.com/workers/runtime-apis/cache/

https://developer.mozilla.org/en-US/docs/Web/API/Cache/match