### PR TITLE
Archive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **Note**
+>
+> This repo is archived, the website has now been rebuilt and lives over at https://github.com/NorfolkDev/nordevcon-website-remixed
+
 # The Norfolk Developer's Website
 
 The website data for speakers and schedule is sourced from an Airtable spreadsheet via the Airtable API.


### PR DESCRIPTION
I'm proposing archiving this repo now the live site lives in another repo now it's been rebuilt.

Steps I think we need to follow are:

1. Rename this repo `nordevcon-website-2020-2022`
2. Rename `nordevcon-website-remixed` to `nordevcon-website`
3. Update the link in this PR to point to `nordevcon-website`
4. Merge this PR
5. Archive this repo